### PR TITLE
Update stochastic_processes.rst

### DIFF
--- a/docs/stochastic_processes.rst
+++ b/docs/stochastic_processes.rst
@@ -159,6 +159,24 @@ GarmanKohlagenProcess
 HestonProcess
 #############
 
+.. function:: ql.HestonProcess(riskFreeTS, dividendTS, initialValue, v0, kappa, theta, sigma, rho)
+
+.. code-block:: python
+
+  today = ql.Date().todaysDate()
+  riskFreeTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.05, ql.Actual365Fixed()))
+  dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
+
+  initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
+  v0 = 0.005
+  kappa = 0.8
+  theta = 0.008
+  rho = 0.2
+  sigma = 0.1
+
+  process = ql.HestonProcess(riskFreeTS, dividendTS, initialValue, v0, kappa, theta, sigma, rho)
+
+
 BatesProcess
 ############
 


### PR DESCRIPTION
Added HestonProcess example within stochastic_processes.rst

First contribution for me - please let me know if I'm doing anything wrong. The sphinx documentation builds and the python code it generates runs (assuming QuantLib is imported). If this is good, I'll get on and add more in the coming days/weeks.

None of the processes currently have further documentation or examples (besides minimal constructor example) so I've kept the same style as the other processes in the file.