### PR TITLE
Adding two engines to price american payoffs, and correcting misleading ordering of variables in BSM process

### DIFF
--- a/docs/pricing_engines.rst
+++ b/docs/pricing_engines.rst
@@ -340,7 +340,7 @@ AnalyticEuropeanEngine
     dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
     volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
     initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
-    process = ql.BlackScholesMertonProcess(initialValue, riskFreeTS, dividendTS, volatility)
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
 
     engine = ql.AnalyticEuropeanEngine(process)
 
@@ -357,7 +357,7 @@ MCEuropeanEngine
     dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
     volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
     initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
-    process = ql.BlackScholesMertonProcess(initialValue, riskFreeTS, dividendTS, volatility)
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
 
     steps = 2
     rng = "pseudorandom" # could use "lowdiscrepancy"
@@ -378,7 +378,7 @@ AnalyticDiscreteGeometricAveragePriceAsianEngine
     dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
     volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
     initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
-    process = ql.BlackScholesMertonProcess(initialValue, riskFreeTS, dividendTS, volatility)
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
 
     engine = ql.AnalyticDiscreteGeometricAveragePriceAsianEngine(process)
 
@@ -395,7 +395,7 @@ AnalyticContinuousGeometricAveragePriceAsianEngine
     dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
     volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
     initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
-    process = ql.BlackScholesMertonProcess(initialValue, riskFreeTS, dividendTS, volatility)
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
 
     engine = ql.AnalyticContinuousGeometricAveragePriceAsianEngine(process)
 
@@ -412,7 +412,7 @@ MCDiscreteGeometricAPEngine
     dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
     volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
     initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
-    process = ql.BlackScholesMertonProcess(initialValue, riskFreeTS, dividendTS, volatility)
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
 
     rng = "pseudorandom" # could use "lowdiscrepancy"
     numPaths = 100000
@@ -432,7 +432,7 @@ MCDiscreteArithmeticAPEngine
     dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
     volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
     initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
-    process = ql.BlackScholesMertonProcess(initialValue, riskFreeTS, dividendTS, volatility)
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
 
     rng = "pseudorandom" # could use "lowdiscrepancy"
     numPaths = 100000

--- a/docs/pricing_engines.rst
+++ b/docs/pricing_engines.rst
@@ -366,6 +366,47 @@ MCEuropeanEngine
     engine = ql.MCEuropeanEngine(process, rng, steps, requiredSamples=numPaths)
 
 
+FdBlackScholesVanillaEngine
+***************************
+
+Note that this engine is capable of pricing both European and American payoffs!
+
+.. function:: ql.FdBlackScholesVanillaEngine(GeneralizedBlackScholesProcess, tGrid, xGrid, dampingSteps=0, schemeDesc=FdmSchemeDesc::Douglas(), localVol=False, illegalLocalVolOverwrite=None)
+
+.. code-block:: python
+
+    today = ql.Date().todaysDate()
+    riskFreeTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.05, ql.Actual365Fixed()))
+    dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
+    volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
+    initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
+
+    tGrid, xGrid = 2000, 200
+    engine = ql.FdBlackScholesVanillaEngine(process, tGrid, xGrid)
+
+
+MCAmericanEngine
+****************
+
+.. function:: ql.MCAmericanEngine(GeneralizedBlackScholesProcess, traits, timeSteps=None, timeStepsPerYear=None, antitheticVariate=False, controlVariate=False, requiredSamples=None, requiredTolerance=None, maxSamples=None, seed=0, polynomOrder=2, polynomType=0, nCalibrationSamples=2048, antitheticVariateCalibration=None, seedCalibration=None)
+
+.. code-block:: python
+
+    today = ql.Date().todaysDate()
+    riskFreeTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.05, ql.Actual365Fixed()))
+    dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.01, ql.Actual365Fixed()))
+    volatility = ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, ql.NullCalendar(), 0.1, ql.Actual365Fixed()))
+    initialValue = ql.QuoteHandle(ql.SimpleQuote(100))
+    process = ql.BlackScholesMertonProcess(initialValue, dividendTS, riskFreeTS, volatility)
+
+    steps = 200
+    rng = "pseudorandom" # could use "lowdiscrepancy"
+    numPaths = 100000
+
+    engine = ql.MCAmericanEngine(process, rng, steps, requiredSamples=numPaths)
+
+
 AnalyticDiscreteGeometricAveragePriceAsianEngine
 ************************************************
 

--- a/docs/pricing_engines.rst
+++ b/docs/pricing_engines.rst
@@ -440,6 +440,42 @@ MCDiscreteArithmeticAPEngine
     engine = ql.MCDiscreteArithmeticAPEngine(process, rng, requiredSamples=numPaths)
 
 
+MCEuropeanBasketEngine
+**********************
+
+.. function:: ql.MCEuropeanBasketEngine(GeneralizedBlackScholesProcess, traits, timeSteps=None, timeStepsPerYear=None, brownianBridge=False, antitheticVariate=False, requiredSamples=None, requiredTolerance=None, maxSamples=None, seed=0)
+
+.. code-block:: python
+
+  # Create a StochasticProcessArray for the various underlyings
+  underlying_spots = [100., 100., 100., 100., 100.]
+  underlying_vols = [0.1, 0.12, 0.13, 0.09, 0.11]
+  underlying_corr_mat = [[1, 0.1, -0.1, 0, 0], [0.1, 1, 0, 0, 0.2], [-0.1, 0, 1, 0, 0], [0, 0, 0, 1, 0.15], [0, 0.2, 0, 0.15, 1]]
+
+  today = ql.Date().todaysDate()
+  day_count = ql.Actual365Fixed()
+  calendar = ql.NullCalendar()
+
+  riskFreeTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.0, day_count))
+  dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.0, day_count))
+
+  processes = [ql.BlackScholesMertonProcess(ql.QuoteHandle(ql.SimpleQuote(x)),
+                                            dividendTS,
+                                            riskFreeTS,
+                                            ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, calendar, y, day_count)))
+               for x, y in zip(underlying_spots, underlying_vols)]
+
+  multiProcess = ql.StochasticProcessArray(processes, underlying_corr_mat)
+
+  # Create the pricing engine
+  rng = "pseudorandom"
+  numSteps = 500000
+  stepsPerYear = 1
+  seed = 43
+
+  engine = ql.MCEuropeanBasketEngine(multiProcess, rng, timeStepsPerYear=stepsPerYear, requiredSamples=numSteps, seed=seed)
+
+
 AnalyticHestonEngine
 ********************
 

--- a/docs/stochastic_processes.rst
+++ b/docs/stochastic_processes.rst
@@ -275,3 +275,26 @@ G2ForwardProcess
 Multiple Processes
 ##################
 
+.. function:: ql.StochasticProcessArray(processes, correlationMatrix)
+
+.. code-block:: python
+
+  underlyingSpots = [100., 100., 100., 100., 100.]
+  underlyingVols = [0.1, 0.12, 0.13, 0.09, 0.11]
+  underlyingCorrMatrix = [[1, 0.1, -0.1, 0, 0], [0.1, 1, 0, 0, 0.2], [-0.1, 0, 1, 0, 0], [0, 0, 0, 1, 0.15], [0, 0.2, 0, 0.15, 1]]
+
+  today = ql.Date().todaysDate()
+  dayCount = ql.Actual365Fixed()
+  calendar = ql.NullCalendar()
+
+  riskFreeTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.0, dayCount))
+  dividendTS = ql.YieldTermStructureHandle(ql.FlatForward(today, 0.0, dayCount))
+
+  processes = [ql.BlackScholesMertonProcess(ql.QuoteHandle(ql.SimpleQuote(x)),
+                                            dividendTS,
+                                            riskFreeTS,
+                                            ql.BlackVolTermStructureHandle(ql.BlackConstantVol(today, calendar, y, dayCount)))
+               for x, y in zip(underlyingSpots, underlyingVols)]
+
+  multiProcess = ql.StochasticProcessArray(processes, underlyingCorrMatrix)
+


### PR DESCRIPTION
Adding documentation for two pricers of american style payoff options.

BSM takes dividend curve before rates curve, my previous documentation had these the wrong way round!