### PR TITLE
Adding explicit calibration parameter choices to SLV process

### DIFF
--- a/docs/pricing_engines.rst
+++ b/docs/pricing_engines.rst
@@ -521,6 +521,8 @@ MCEuropeanHestonEngine
 FdHestonVanillaEngine
 ---------------------
 
+If a leverage function is passed in to this function, it prices using the Heston Stochastic Local Vol model
+
 .. function:: ql.FdHestonVanillaEngine(HestonModel, tGrid=100, xGrid=100, vGrid=50, dampingSteps=0, FdmSchemeDesc==FdmSchemeDesc::Hundsdorfer(), leverageFct=LocalVolTermStructure())
 
 .. code-block:: python

--- a/docs/stochastic_processes.rst
+++ b/docs/stochastic_processes.rst
@@ -214,10 +214,14 @@ HestonSLVProcess
     localVol.enableExtrapolation()
 
     # Calibrate Leverage Function to the Local Vol and Heston Model via Monte-Carlo
+    timeStepsPerYear = 365
+    nBins = 201
+    calibrationPaths = 2**15
+
     generatorFactory = ql.MTBrownianGeneratorFactory()
 
     hestonModel = ql.HestonModel(hestonProcess)
-    stochLocalMcModel = ql.HestonSLVMCModel(localVol, hestonModel, generatorFactory, endDate)
+    stochLocalMcModel = ql.HestonSLVMCModel(localVol, hestonModel, generatorFactory, endDate, timeStepsPerYear, nBins, calibrationPaths)
     leverageFct = stochLocalMcModel.leverageFunction()
 
     process = ql.HestonSLVProcess(hestonProcess, leverageFct)


### PR DESCRIPTION
The Leverage Function in SLV often needs a larger number of paths to converge sensibly, making this dependence explicit here.