### PR TITLE
Update vol.rst to include usage of ql.nullDouble()

### DIFF
--- a/docs/helpers/vol.rst
+++ b/docs/helpers/vol.rst
@@ -72,7 +72,7 @@ SwaptionHelper
   fixedLegTenor = ql.Period('1Y')
   fixedLegDayCounter = ql.Thirty360()
   floatingLegDayCounter = ql.Actual360()
-  blackCalibrationHekper = ql.BlackCalibrationHelper.RelativePriceError
+  blackCalibrationHelper = ql.BlackCalibrationHelper.RelativePriceError
   strike = ql.nullDouble()
   nominal = 1.0
 
@@ -82,7 +82,7 @@ SwaptionHelper
   ql.SwaptionHelper(
     exerciseDate, endDate, volatility, index, fixedLegTenor,
     fixedLegDayCounter, floatingLegDayCounter, yts,
-    blackCalibrationHekper, strike, nominal
+    blackCalibrationHelper, strike, nominal
   )
 
 

--- a/docs/helpers/vol.rst
+++ b/docs/helpers/vol.rst
@@ -72,13 +72,17 @@ SwaptionHelper
   fixedLegTenor = ql.Period('1Y')
   fixedLegDayCounter = ql.Thirty360()
   floatingLegDayCounter = ql.Actual360()
+  blackCalibrationHekper = ql.BlackCalibrationHelper.RelativePriceError
+  strike = ql.nullDouble()
+  nominal = 1.0
 
   crv = ql.FlatForward(2, ql.TARGET(), 0.05, ql.Actual360())
   yts = ql.YieldTermStructureHandle(crv)
 
   ql.SwaptionHelper(
     exerciseDate, endDate, volatility, index, fixedLegTenor,
-    fixedLegDayCounter, floatingLegDayCounter, yts
+    fixedLegDayCounter, floatingLegDayCounter, yts,
+    blackCalibrationHekper, strike, nominal
   )
 
 


### PR DESCRIPTION
Current documentation does not make clear that ql.nullDouble() can be used to set the strike to Null. Reason for clearing up is this issue: https://github.com/lballabio/QuantLib/issues/927.