### PR TITLE
Adding the requiredTimes constructor for TimeGrid

### DIFF
--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -448,3 +448,12 @@ TimeGrid
 
     t = ql.TimeGrid(10, 5)
     t.dt(4)
+
+
+If there are certain times that need to appear in the TimeGrid, pass them in as a list
+
+.. function:: ql.TimeGrid(requiredTimes, steps)
+
+.. code-block:: python
+
+    [t for t in ql.TimeGrid([1, 2.5, 4], 10)]


### PR DESCRIPTION
A super-useful constructor for TimeGrid that allows you to force certain times (eg. fixing dates) into the TimeGrid