### PR TITLE
Remove extra space in the codeblock of FraRateHelper

### DIFF
--- a/docs/helpers/rates.rst
+++ b/docs/helpers/rates.rst
@@ -60,10 +60,10 @@ from months with quote
   convention = ql.ModifiedFollowing
   endOfMonth = False
   dayCounter = ql.Actual360()
-  ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter)
-  ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate)
-  ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date())
-  ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date(), True)
+  ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter)
+  ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate)
+  ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date())
+  ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date(), True)
 
 
 from months with rate
@@ -82,10 +82,10 @@ from months with rate
   convention = ql.ModifiedFollowing
   endOfMonth = False
   dayCounter = ql.Actual360()
-  ql.FraRateHelper (rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter)
-  ql.FraRateHelper (rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate)
-  ql.FraRateHelper (rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date())
-  ql.FraRateHelper (rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date(), True)
+  ql.FraRateHelper(rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter)
+  ql.FraRateHelper(rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate)
+  ql.FraRateHelper(rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date())
+  ql.FraRateHelper(rate, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date(), True)
 
 
 


### PR DESCRIPTION
Hi,

Removed the extra space in the code block for FraRateHelper for "from months with quote" and "from months with rate". As of now the code block has the following form:
```
quote = ql.QuoteHandle(ql.SimpleQuote(0.05))  
...  
...  
...  
ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter)  
ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter,  ql.Pillar.LastRelevantDate)  
ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date())  
ql.FraRateHelper (quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date(), True) 
```

and hopefully the changes will turn it to 

```
quote = ql.QuoteHandle(ql.SimpleQuote(0.05))   
...
...
...
ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter)   
ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate)   
ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date())   
ql.FraRateHelper(quote, monthsToStart, monthsToEnd, fixingDays, calendar, convention, endOfMonth, dayCounter, ql.Pillar.LastRelevantDate, ql.Date(), True)   
```


Thanks!