### PR TITLE
Daycount on FixedRateBondHelper and BondHelper

### DIFF
--- a/docs/helpers/rates.rst
+++ b/docs/helpers/rates.rst
@@ -519,7 +519,7 @@ FixedRateBondHelper
   faceAmount = 100
   schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2021), ql.Period('1y'))
   coupons = [0.0195]
-  dayCounter = ql.ActualActual()
+  dayCounter = ql.Actual360()
   helper = ql.FixedRateBondHelper(quote, settlementDays, faceAmount, schedule, coupons, dayCounter)
 
 BondHelper
@@ -531,7 +531,7 @@ BondHelper
 
   bond = ql.FixedRateBond(
       2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024),
-      ql.Period('1Y'), [0.05], ql.ActualActual())
+      ql.Period('1Y'), [0.05], ql.Actual360())
 
   cleanPrice = ql.QuoteHandle(ql.SimpleQuote(115))
   ql.BondHelper(cleanPrice, bond)


### PR DESCRIPTION
Hi,

The following examples

```
quote = ql.QuoteHandle(ql.SimpleQuote(115.5))
settlementDays = 2
faceAmount = 100
schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2021), ql.Period('1y'))
coupons = [0.0195]
dayCounter = ql.ActualActual()
helper = ql.FixedRateBondHelper(quote, settlementDays, faceAmount, schedule, coupons, dayCounter)
```
and 
```
bond = ql.FixedRateBond(
    2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024),
    ql.Period('1Y'), [0.05], ql.ActualActual())

cleanPrice = ql.QuoteHandle(ql.SimpleQuote(115))
ql.BondHelper(cleanPrice, bond)
``` 
Throws the respective errors 
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~\AppData\Local\Temp\ipykernel_23920\3805062853.py in <cell line: 6>()
      4 schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2021), ql.Period('1y'))
      5 coupons = [0.0195]
----> 6 dayCounter = ql.ActualActual()
      7 helper = ql.FixedRateBondHelper(quote, settlementDays, faceAmount, schedule, coupons, dayCounter)

lib\site-packages\QuantLib\QuantLib.py in __init__(self, *args)
   3508 
   3509     def __init__(self, *args):
-> 3510         _QuantLib.ActualActual_swiginit(self, _QuantLib.new_ActualActual(*args))
   3511     __swig_destroy__ = _QuantLib.delete_ActualActual
   3512 

TypeError: Wrong number or type of arguments for overloaded function 'new_ActualActual'.
  Possible C/C++ prototypes are:
    QuantLib::ActualActual::ActualActual(QuantLib::ActualActual::Convention,Schedule const &)
    QuantLib::ActualActual::ActualActual(QuantLib::ActualActual::Convention)
``` 
and
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~\AppData\Local\Temp\ipykernel_23920\3308381297.py in <cell line: 1>()
      1 bond = ql.FixedRateBond(
      2     2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024),
----> 3     ql.Period('1Y'), [0.05], ql.ActualActual())
      4 
      5 cleanPrice = ql.QuoteHandle(ql.SimpleQuote(115))

lib\site-packages\QuantLib\QuantLib.py in __init__(self, *args)
   3508 
   3509     def __init__(self, *args):
-> 3510         _QuantLib.ActualActual_swiginit(self, _QuantLib.new_ActualActual(*args))
   3511     __swig_destroy__ = _QuantLib.delete_ActualActual
   3512 

TypeError: Wrong number or type of arguments for overloaded function 'new_ActualActual'.
  Possible C/C++ prototypes are:
    QuantLib::ActualActual::ActualActual(QuantLib::ActualActual::Convention,Schedule const &)
    QuantLib::ActualActual::ActualActual(QuantLib::ActualActual::Convention)
``` 
on QuantLib 1.28 and Python 3.10.4. Therefore I propose modifying the day counter to ql.Actual360() on both examples which works on my machine. However, I am aware it is possible to change it to something like ql.ActualActual(ql.ActualActual.ISMA) but I think it is easier for beginners to read ql.Actual360().