### PR TITLE
Update dates.rst with conventions for Thirty360

### DIFF
--- a/docs/dates.rst
+++ b/docs/dates.rst
@@ -360,7 +360,6 @@ https://www.isda.org/a/pIJEE/The-Actual-Actual-Day-Count-Fraction-1999.pdf
 The “Day Count Convention” is critical for the valuation of financial products, especially for fixed-income products. QuantLib provides the following common rules:
 
 - **Actual360** : Actual / 360
-
 - **Actual365Fixed** : Actual / 365(Fixed)
  - Standard
  - Canadian
@@ -375,6 +374,15 @@ The “Day Count Convention” is critical for the valuation of financial produc
  - Euro
 - **Business252** : Business / 252
 - **Thirty360** : 30 / 360
+ - USA
+ - BondBasis
+ - European
+ - EurobondBasis 
+ - Italian
+ - German
+ - ISMA
+ - ISDA 
+ - NASD
 - **SimpleDayCounter**
 
 .. code-block:: python


### PR DESCRIPTION
Hi

I though to add the following public types https://rkapl123.github.io/QLAnnotatedSource/d5/d63/class_quant_lib_1_1_thirty360.html to Thirty360, as without them I keep getting an error with helpers using Thirty360. For example if we run the example below we get the following error:

```
TypeError: Wrong number or type of arguments for overloaded function 'new_Thirty360'.
  Possible C/C++ prototypes are:
    QuantLib::Thirty360::Thirty360(QuantLib::Thirty360::Convention,Date const &)
    QuantLib::Thirty360::Thirty360(QuantLib::Thirty360::Convention)
```