### PR TITLE
Fixed errors related to DayCounter in bond.rst, etc.

### DIFF
--- a/docs/instruments/bonds.rst
+++ b/docs/instruments/bonds.rst
@@ -87,7 +87,7 @@ FloatingRateBond
 
     schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2022), ql.Period('6m'))
     index = ql.Euribor6M()
-    ql.FloatingRateBond(2,100, schedule, index, ql.Actual360(), spreads=[0.01])
+    bond = ql.FloatingRateBond(2,100, schedule, index, ql.Actual360(), spreads=[0.01])
 
 
 AmortizingFloatingRateBond
@@ -100,7 +100,7 @@ AmortizingFloatingRateBond
     notional = [100, 50]
     schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2022), ql.Period('1Y'))
     index = ql.Euribor6M()
-    ql.AmortizingFloatingRateBond(2, notional, schedule, index, ql.ActualActual(ql.ActualActual.Bond))
+    bond = ql.AmortizingFloatingRateBond(2, notional, schedule, index, ql.ActualActual(ql.ActualActual.Bond))
 
 
 CMS Rate Bond
@@ -113,7 +113,7 @@ CMS Rate Bond
 
     schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2022), ql.Period('1Y'))
     index = ql.EuriborSwapIsdaFixA(ql.Period('10y'))
-    ql.CmsRateBond(2, 100, schedule, index, ql.Actual360(), ql.ModifiedFollowing, fixingDays=2, gearings=[1], spreads=[0], caps=[], floors=[])
+    bond = ql.CmsRateBond(2, 100, schedule, index, ql.Actual360(), ql.ModifiedFollowing, fixingDays=2, gearings=[1], spreads=[0], caps=[], floors=[])
 
 
 Callable Bond
@@ -132,7 +132,7 @@ Callable Bond
         ql.Callability(my_price, ql.Callability.Call, ql.Date(15,6,2021))
     )
 
-    ql.CallableFixedRateBond(2, 100, schedule, [0.01], ql.Actual360(), ql.ModifiedFollowing, 100, ql.Date(15,6,2020), putCallSchedule)
+    bond = ql.CallableFixedRateBond(2, 100, schedule, [0.01], ql.Actual360(), ql.ModifiedFollowing, 100, ql.Date(15,6,2020), putCallSchedule)
 
 
 Convertible Bond

--- a/docs/instruments/bonds.rst
+++ b/docs/instruments/bonds.rst
@@ -64,7 +64,7 @@ FixedRateBond
 
 .. code-block:: python
 
-    bond = ql.FixedRateBond(2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024), ql.Period('1Y'), [0.05], ql.ActualActual())
+    bond = ql.FixedRateBond(2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024), ql.Period('1Y'), [0.05], ql.ActualActual(ql.ActualActual.Bond))
 
 AmortizingFixedRateBond
 -----------------------
@@ -75,7 +75,7 @@ AmortizingFixedRateBond
 
     notionals = [100,100,100,50]
     schedule = ql.MakeSchedule(ql.Date(25,1,2018), ql.Date(25,1,2022), ql.Period('1y'))
-    bond = ql.AmortizingFixedRateBond(0, notionals, schedule, [0.03], ql.Thirty360())
+    bond = ql.AmortizingFixedRateBond(0, notionals, schedule, [0.03], ql.Thirty360(ql.Thirty360.USA))
     
 
 FloatingRateBond
@@ -100,7 +100,7 @@ AmortizingFloatingRateBond
     notional = [100, 50]
     schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2022), ql.Period('1Y'))
     index = ql.Euribor6M()
-    ql.AmortizingFloatingRateBond(2, notional, schedule, index, ql.ActualActual())
+    ql.AmortizingFloatingRateBond(2, notional, schedule, index, ql.ActualActual(ql.ActualActual.Bond))
 
 
 CMS Rate Bond
@@ -147,7 +147,7 @@ BondFunctions
     bond = ql.FixedRateBond(
         2, ql.TARGET(), 100.0,
         ql.Date(15,12,2019), ql.Date(15,12,2024), ql.Period('1Y'),
-        [0.05], ql.ActualActual())
+        [0.05], ql.ActualActual(ql.ActualActual.Bond))
 
 **Date Inspectors**
 

--- a/docs/instruments/bonds.rst
+++ b/docs/instruments/bonds.rst
@@ -126,10 +126,10 @@ Callable Bond
     schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2022), ql.Period('1Y'))
     putCallSchedule = ql.CallabilitySchedule()
 
-    callability_price  = ql.CallabilityPrice(100, ql.CallabilityPrice.Clean)
+    my_price  = ql.BondPrice(100, ql.BondPrice.Clean)
 
     putCallSchedule.append(
-        ql.Callability(callability_price, ql.Callability.Call, ql.Date(15,6,2021))
+        ql.Callability(my_price, ql.Callability.Call, ql.Date(15,6,2021))
     )
 
     ql.CallableFixedRateBond(2, 100, schedule, [0.01], ql.Actual360(), ql.ModifiedFollowing, 100, ql.Date(15,6,2020), putCallSchedule)


### PR DESCRIPTION
# https://github.com/nhaga/QuantLib-Python-Docs/commit/5ede01b20263220d23b80f06f67b942ee1c45f29 Fixed an error that occurred because the code using the DayCounter class was not updated.

An example code to make an instance of FixedRateBond rases an eror.
```python
bond = ql.FixedRateBond(2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024), ql.Period('1Y'), [0.05], ql.ActualActual())
```
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~\AppData\Local\Temp/ipykernel_7184/3508350746.py in <module>
      1 # エラー
----> 2 bond = ql.FixedRateBond(2, ql.TARGET(), 100.0, ql.Date(15,12,2019), ql.Date(15,12,2024), ql.Period('1Y'), [0.05], ql.ActualActual())

c:\Users\kentr\.venvs\base\lib\site-packages\QuantLib\QuantLib.py in __init__(self, *args)
   5058     def __init__(self, *args):
   5059         r"""__init__(ActualActual self, QuantLib::ActualActual::Convention c, Schedule schedule=Schedule()) -> ActualActual"""
-> 5060         _QuantLib.ActualActual_swiginit(self, _QuantLib.new_ActualActual(*args))
   5061     __swig_destroy__ = _QuantLib.delete_ActualActual
   5062 

TypeError: Wrong number or type of arguments for overloaded function 'new_ActualActual'.
  Possible C/C++ prototypes are:
    QuantLib::ActualActual::ActualActual(QuantLib::ActualActual::Convention,Schedule const &)
    QuantLib::ActualActual::ActualActual(QuantLib::ActualActual::Convention)
```

I modified to suppress the above error.

# https://github.com/nhaga/QuantLib-Python-Docs/commit/73cccb3fdb2a046cb82f1517c816747ea6d115ef The CallableFixedRateBond example has been modified to correspond to the parent repository's commitment.

```python
schedule = ql.MakeSchedule(ql.Date(15,6,2020), ql.Date(15,6,2022), ql.Period('1Y'))
putCallSchedule = ql.CallabilitySchedule()

callability_price  = ql.CallabilityPrice(100, ql.CallabilityPrice.Clean)

putCallSchedule.append(
    ql.Callability(callability_price, ql.Callability.Call, ql.Date(15,6,2021))
)

ql.CallableFixedRateBond(
    2, 100, schedule, [0.01], 
    ql.Actual360(), ql.ModifiedFollowing, 
    100, ql.Date(15,6,2020), putCallSchedule)
```

The above code rase the error below.

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~\AppData\Local\Temp/ipykernel_7184/4107562983.py in <module>
      2 putCallSchedule = ql.CallabilitySchedule()
      3 
----> 4 callability_price  = ql.CallabilityPrice(100, ql.CallabilityPrice.Clean)
      5 
      6 putCallSchedule.append(

AttributeError: module 'QuantLib' has no attribute 'CallabilityPrice'
```

I modified to correspond to the following commitment.
https://github.com/lballabio/QuantLib/commit/344cce864168cc95262cab50c110018d0e3a1915

# https://github.com/nhaga/QuantLib-Python-Docs/commit/f73524c08b8747e225c58efffa50a86bc34ac290 For consistency, modified codes so that instances are stored in variable `bond`.

This is a minor correction and does not need to be merged.