### PR TITLE
Update vanillaswap.ipynb

### DIFF
--- a/docs/examples/fixedincome/vanillaswap.ipynb
+++ b/docs/examples/fixedincome/vanillaswap.ipynb
@@ -1,36 +1,15 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.6-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python37664bitsphxcondaad2406a3d9da4560bbafc5d9351938d9",
-   "display_name": "Python 3.7.6 64-bit ('sphx': conda)"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Vanilla Swap"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,11 +17,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Create a relinkable yield term structure handle and build a curve"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -54,7 +33,6 @@
     "\n",
     "instruments = [\n",
     "    ('depo', '6M', 0.025),\n",
-    "    ('fra', '6M', 0.03),\n",
     "    ('swap', '1Y', 0.031),\n",
     "    ('swap', '2Y', 0.032),\n",
     "    ('swap', '3Y', 0.035)\n",
@@ -71,15 +49,15 @@
     "    if instrument == 'swap':\n",
     "        swapIndex = ql.EuriborSwapIsdaFixA(ql.Period(tenor))\n",
     "        helpers.append( ql.SwapRateHelper(rate, swapIndex))\n",
-    "curve = ql.PiecewiseLogCubicDiscount(2, ql.TARGET(), helpers, ql.ActualActual())\n"
+    "curve = ql.PiecewiseLogCubicDiscount(2, ql.TARGET(), helpers, ql.Actual365Fixed())\n"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Link the built curve to the relinkable yield term structure handle and build a swap pricing engine"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -92,11 +70,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Build a vanilla swap and provide a pricing engine"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -112,11 +90,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Get the fair rate and NPV"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -126,9 +104,12 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Fair swap rate: 3.232%\nSwap NPV: -337,608.498\n"
+     "output_type": "stream",
+     "text": [
+      "Fair swap rate: 3.205%\n",
+      "Swap NPV: -343,527.872\n"
+     ]
     }
    ],
    "source": [
@@ -141,16 +122,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "                date      amount\n0    April 6th, 2021  129,166.12\n1  October 5th, 2021  166,342.17\n2    April 5th, 2022 -100,976.64\n3  October 5th, 2022  455,178.07",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>date</th>\n      <th>amount</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>April 6th, 2021</td>\n      <td>129,166.12</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>October 5th, 2021</td>\n      <td>166,342.17</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>April 5th, 2022</td>\n      <td>-100,976.64</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>October 5th, 2022</td>\n      <td>455,178.07</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>amount</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>January 19th, 2024</td>\n",
+       "      <td>128,288.65</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>July 19th, 2024</td>\n",
+       "      <td>180,166.24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>January 20th, 2025</td>\n",
+       "      <td>166,690.49</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>July 21st, 2025</td>\n",
+       "      <td>162,876.45</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 date     amount\n",
+       "0  January 19th, 2024 128,288.65\n",
+       "1     July 19th, 2024 180,166.24\n",
+       "2  January 20th, 2025 166,690.49\n",
+       "3     July 21st, 2025 162,876.45"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -166,16 +200,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "        nominal accrualStartDate accrualEndDate  rate      amount\n0 10,000,000.00       2020-10-05     2021-04-06  0.03  129,166.12\n1 10,000,000.00       2021-04-06     2021-10-05  0.03  166,342.17\n2 10,000,000.00       2021-10-05     2022-04-05 -0.02 -100,976.64\n3 10,000,000.00       2022-04-05     2022-10-05  0.09  455,178.07",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>nominal</th>\n      <th>accrualStartDate</th>\n      <th>accrualEndDate</th>\n      <th>rate</th>\n      <th>amount</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>10,000,000.00</td>\n      <td>2020-10-05</td>\n      <td>2021-04-06</td>\n      <td>0.03</td>\n      <td>129,166.12</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>10,000,000.00</td>\n      <td>2021-04-06</td>\n      <td>2021-10-05</td>\n      <td>0.03</td>\n      <td>166,342.17</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>10,000,000.00</td>\n      <td>2021-10-05</td>\n      <td>2022-04-05</td>\n      <td>-0.02</td>\n      <td>-100,976.64</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>10,000,000.00</td>\n      <td>2022-04-05</td>\n      <td>2022-10-05</td>\n      <td>0.09</td>\n      <td>455,178.07</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>nominal</th>\n",
+       "      <th>accrualStartDate</th>\n",
+       "      <th>accrualEndDate</th>\n",
+       "      <th>rate</th>\n",
+       "      <th>amount</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10,000,000.00</td>\n",
+       "      <td>2023-07-19</td>\n",
+       "      <td>2024-01-19</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>128,288.65</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10,000,000.00</td>\n",
+       "      <td>2024-01-19</td>\n",
+       "      <td>2024-07-19</td>\n",
+       "      <td>0.04</td>\n",
+       "      <td>180,166.24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10,000,000.00</td>\n",
+       "      <td>2024-07-19</td>\n",
+       "      <td>2025-01-20</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>166,690.49</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>10,000,000.00</td>\n",
+       "      <td>2025-01-20</td>\n",
+       "      <td>2025-07-21</td>\n",
+       "      <td>0.03</td>\n",
+       "      <td>162,876.45</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        nominal accrualStartDate accrualEndDate  rate     amount\n",
+       "0 10,000,000.00       2023-07-19     2024-01-19  0.03 128,288.65\n",
+       "1 10,000,000.00       2024-01-19     2024-07-19  0.04 180,166.24\n",
+       "2 10,000,000.00       2024-07-19     2025-01-20  0.03 166,690.49\n",
+       "3 10,000,000.00       2025-01-20     2025-07-21  0.03 162,876.45"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -188,6 +290,35 @@
     "    } for cf in map(ql.as_coupon, swap.leg(1)))\n",
     "display(cashflows)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Hi,

vanillaswap.ipynb was throwing errors as pointed out by the following issue: https://github.com/nhaga/QuantLib-Python-Docs/issues/46

I then did the following modifications:
- Changed ql.ActualActual() to ql.Actual365Fixed() in ql.PiecewiseLogCubicDiscount.
- Removed the FRA from the instruments as it would have the same maturity date as the first swap.